### PR TITLE
Only alphanumerics and single underscore allowed in config ids

### DIFF
--- a/rules/common_func1.smk
+++ b/rules/common_func1.smk
@@ -25,8 +25,6 @@ def check_safe_id(list_of_strings):
         '''
         for val in list_of_strings:
                 if not re.search(_ALLOWED_ID_PATTERN, val):
-                    continue
-                else:
                     return False
         return True
 

--- a/rules/common_func1.smk
+++ b/rules/common_func1.smk
@@ -12,7 +12,7 @@ min_version("5.27")
 
 
 
-_ALLOWED_ID_PATTERN = "^(?!.*__.*)[a-z][a-z0-9_-]+$"
+_ALLOWED_ID_PATTERN = "^(?!.*__.*)[A-Za-z0-9_-]*$"
 
 
 ########################################################################################
@@ -21,12 +21,14 @@ _ALLOWED_ID_PATTERN = "^(?!.*__.*)[a-z][a-z0-9_-]+$"
 
 def check_safe_id(list_of_strings):
         '''
-        Returns False if any string in list_of_strings contains the patterns defined in _ALLOWED_ID_PATTERN.
+        Returns False if any string in list_of_strings contains the patterns defined in _ILLEGAL_ID_PATTERN.
         '''
         for val in list_of_strings:
-                if re.search(_ALLOWED_ID_PATTERN, val):
-                        return True
-        return False
+                if not re.search(_ALLOWED_ID_PATTERN, val):
+                    continue
+                else:
+                    return False
+        return True
 
 
 def check_conditional_and_heritability_config_sections(config_section_string):

--- a/rules/common_func1.smk
+++ b/rules/common_func1.smk
@@ -21,7 +21,7 @@ _ALLOWED_ID_PATTERN = "^(?!.*__.*)[a-z][a-z0-9_-]+$"
 
 def check_safe_id(list_of_strings):
         '''
-        Returns False if any string in list_of_strings contains the patterns defined in _ILLEGAL_ID_PATTERN.
+        Returns False if any string in list_of_strings contains the patterns defined in _ALLOWED_ID_PATTERN.
         '''
         for val in list_of_strings:
                 if re.search(_ALLOWED_ID_PATTERN, val):

--- a/rules/common_func1.smk
+++ b/rules/common_func1.smk
@@ -12,7 +12,7 @@ min_version("5.27")
 
 
 
-_ILLEGAL_ID_PATTERN = r"\s|__|/"
+_ALLOWED_ID_PATTERN = "^(?!.*__.*)[a-z][a-z0-9_-]+$"
 
 
 ########################################################################################
@@ -24,9 +24,9 @@ def check_safe_id(list_of_strings):
         Returns False if any string in list_of_strings contains the patterns defined in _ILLEGAL_ID_PATTERN.
         '''
         for val in list_of_strings:
-                if re.search(_ILLEGAL_ID_PATTERN, val):
-                        return False
-        return True
+                if re.search(_ALLOWED_ID_PATTERN, val):
+                        return True
+        return False
 
 
 def check_conditional_and_heritability_config_sections(config_section_string):

--- a/rules/common_func2.smk
+++ b/rules/common_func2.smk
@@ -17,12 +17,12 @@ ANNOTATIONS_DICT = get_annots(SPECIFICITY_INPUT)
 
 ### Check names/ids
 if not check_safe_id(list(SPECIFICITY_INPUT.keys())):
-        raise Exception("Illegal charecters in SPECIFICITY_INPUT id's. Illegal charecters=[{}]".format(_ILLEGAL_ID_PATTERN))
+        raise Exception("Illegal charecters in SPECIFICITY_INPUT id's. Only letters, numbers, and single underscores allowed.")
 if not check_safe_id(list(GWAS_SUMSTATS.keys())):
-        raise Exception("Illegal charecters in GWAS SUMSTATS id's. Illegal charecters=[{}]".format(_ILLEGAL_ID_PATTERN))
+        raise Exception("Illegal charecters in GWAS SUMSTATS id's. Only letters, numbers, and single underscores allowed.")
 for key in ANNOTATIONS_DICT:
         if not check_safe_id(ANNOTATIONS_DICT[key]):
-                raise Exception("Illegal charecters in SPECIFICITY_INPUT={} annotation names. Illegal charecters=[{}]".format(key, _ILLEGAL_ID_PATTERN))
+                raise Exception("Illegal charecters in SPECIFICITY_INPUT={} annotation names. Only letters, numbers, and single underscores allowed.")
 
 
 if config['ANALYSIS_TYPE']['conditional']:

--- a/rules/common_func2.smk
+++ b/rules/common_func2.smk
@@ -17,8 +17,10 @@ ANNOTATIONS_DICT = get_annots(SPECIFICITY_INPUT)
 
 ### Check names/ids
 if not check_safe_id(list(SPECIFICITY_INPUT.keys())):
+        print(list(SPECIFICITY_INPUT.keys()))
         raise Exception("Illegal charecters in SPECIFICITY_INPUT id's. Only letters, numbers, and single underscores allowed.")
 if not check_safe_id(list(GWAS_SUMSTATS.keys())):
+        print(list(GWAS_SUMSTATS.keys()))
         raise Exception("Illegal charecters in GWAS SUMSTATS id's. Only letters, numbers, and single underscores allowed.")
 for key in ANNOTATIONS_DICT:
         if not check_safe_id(ANNOTATIONS_DICT[key]):


### PR DESCRIPTION
- only allow alphanumeric characters in the config ids
- prior code existed to exclude double underscores, but additional characters caused silent issues